### PR TITLE
[Phase 1] 게이트웨이 설정 및 라우팅

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
       server:
         webflux:
           default-filters:
-            - AddRequestHeader=X-gateway, donghyeon.site
+            - AddRequestHeader=X-gateway, donghyeon.site # 먼저 적용됨
           routes:
             - id: test-route
               uri: https://httpbin.org
@@ -29,6 +29,7 @@ spring:
               filters:
                 - RewritePath=/search(?<segment>/?.*), /anything$\{segment} # prefix 변경
                 - AddResponseHeader=Cookie, chocolate
+                - AddRequestHeader=X-gateway, api-gateway # 덮어쓰기가 아니라 추가됨
 
             - id: booking
               uri: https://httpbin.org

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,9 +21,17 @@ spring:
               uri: https://httpbin.org/anything
               predicates:
                 - Path=/search/**
-#              filters:
-#                - StripPrefix=1
-#               GET /search 로 요청을 보내면 uri에 /anything이 있어도 /anything을 무시하고 도메인 루트로 리디렉션.
-#               StripPrefix를 활용하는 경우 /search/status 처럼 하위 경로가 있어야 /anything/status로 정상 라우팅
+              #  GET /search 로 요청을 보내면 uri에 /anything이 있어도 /anything을 무시하고 도메인 루트로 리디렉션.
+              #  StripPrefix를 활용하는 경우 /search/status 처럼 하위 경로가 있어야 /anything/status로 정상 라우팅
+              #  Producation 환경에서는 일반적으로 uri에 추가적인 경로가 붙지 않기 때문에 사용할 필요는 없을 것 같음.
               filters:
                 - RewritePath=/search(?<segment>/?.*), /anything$\{segment} # prefix 변경
+
+            - id: booking
+              uri: https://httpbin.org
+              predicates:
+                - Path=/book/**
+              filters:
+                - StripPrefix=1
+              # 추가 헤더 설정
+                - AddRequestHeader=X-Gateway, donghyeon.site

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,14 @@ spring:
                 - Path=/test/**
               filters:
                 - StripPrefix=1 # 제거할 경로 세그먼트 개수
+
+            - id: search
+              uri: https://httpbin.org/anything
+              predicates:
+                - Path=/search/**
+#              filters:
+#                - StripPrefix=1
+#               GET /search 로 요청을 보내면 uri에 /anything이 있어도 /anything을 무시하고 도메인 루트로 리디렉션.
+#               StripPrefix를 활용하는 경우 /search/status 처럼 하위 경로가 있어야 /anything/status로 정상 라우팅
+              filters:
+                - RewritePath=/search(?<segment>/?.*), /anything$\{segment} # prefix 변경

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,3 +36,11 @@ spring:
                 - StripPrefix=1
               # 추가 헤더 설정
                 - AddRequestHeader=X-Gateway, donghyeon.site
+
+            - id: queue
+              uri: https://httpbin.org
+              predicates:
+                - Path=/queue/**
+              filters:
+                - StripPrefix=1
+                - RemoveRequestHeader=Cookie

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,7 @@ spring:
               #  Producation 환경에서는 일반적으로 uri에 추가적인 경로가 붙지 않기 때문에 사용할 필요는 없을 것 같음.
               filters:
                 - RewritePath=/search(?<segment>/?.*), /anything$\{segment} # prefix 변경
+                - AddResponseHeader=Cookie, chocolate
 
             - id: booking
               uri: https://httpbin.org

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,8 @@ spring:
     gateway:
       server:
         webflux:
+          default-filters:
+            - AddRequestHeader=X-gateway, donghyeon.site
           routes:
             - id: test-route
               uri: https://httpbin.org
@@ -34,8 +36,6 @@ spring:
                 - Path=/book/**
               filters:
                 - StripPrefix=1
-              # 추가 헤더 설정
-                - AddRequestHeader=X-Gateway, donghyeon.site
 
             - id: queue
               uri: https://httpbin.org

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,15 @@ server:
 spring:
   application:
     name: api-gateway
+
+  cloud:
+    gateway:
+      server:
+        webflux:
+          routes:
+            - id: test-route
+              uri: https://httpbin.org
+              predicates:
+                - Path=/test/**
+              filters:
+                - StripPrefix=1 # 제거할 경로 세그먼트 개수


### PR DESCRIPTION
# 🧩 PR 요약
> 이번 PR의 목적과 핵심 변경사항을 간단히 적어주세요.  
(예: Redis 리더보드 구현)

- 구현 기능:
  - spring cloud gateway 기반 기본 게이트웨이 설정 ( `/test`, `/search`, `/book`, `/queue` )
  - 각 라우트 별 필터 적용 (RemoveRequestHeader, AddRequestHeader, AddResponseHeader, RewritePath, StripPrefix 등) 
  - 글로벌 필터 적용 (default-filters)

- 수정/리팩토링 내용:

- 추가된 설정/의존성:

---

## ⚙️ 주요 구현 내용
> 구현된 기능의 흐름이나 의도, 설계상의 선택 이유를 간단히 정리해주세요.  

- spring cloud gateway를 통한 게이트웨이 서버 구현을 학습했습니다.
- 라우트 별 필터를 실제로 적용하며 실제 적용 시 요청과 응답이 어떻게 바뀌는지 `httpbin.org`를 통해 확인했습니다.
- `default-filters`를 통해 모든 라우트에 공통으로 적용되는 필터를 설정했습니다.

---

## 🧠 학습 포인트 / 검증 이론
> 이번 작업에서 학습하거나 검증하고 싶은 기술적 개념을 기록합니다.  

- Spring Cloud Gateway 는 WebFlux 기반으로 동작하며, Tomcat이 아닌 Netty 웹 서버를 사용합니다.
  - `spring-cloud-starter-gateway-server-webmvc`도 존재하지만, 네이밍에 따른 것이고, 내부적으로는 항상 WebFlux 기반이었습니다.
  - 
- `predicate` 에서 라우팅 조건을 정의하고, `filters`에서 요청/응답을 변환할 수 있습니다. 
- `default-filters`에서 선언한 필터가 개별 라우트에 적용한 필터보다 우선합니다.

---

## ✅ 검증 및 테스트
> PR을 올리기 전에 확인한 사항을 체크해주세요.

- [x] 빌드 및 서버 실행 확인 (`./gradlew bootRun`)
- [x] 신규 API 테스트 완료
- [x] 로깅/예외 처리 정상 동작
- [x] 불필요한 로그 제거
- [x] 학습 내용을 커밋 메시지 또는 주석으로 요약

---

## 📚 참고 자료
> 참고한 공식 문서나 블로그, 영상 링크 등을 작성해주세요.

- 공식 문서: [Spring Cloud Gateway Documentation](https://docs.spring.io/spring-cloud-gateway/docs/current/reference/html/)
- 블로그/자료:
- 기타 참고 링크: [httpbin.org](https://httpbin.org)

---

## 🚀 다음 학습/개선 아이디어 (선택)
> 이번 구현을 기반으로 더 시도해볼 내용이 있다면 적어주세요.

- `predicate`에서 `Path` 뿐만 아니라 `Method`, `Header`, `Query`, `Cookie`등  다양한 조건을 조합해서 라우팅할 수 있어, 다양하게 확장할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway routing added for Search, Booking, and Queue endpoints, plus a test diagnostics route.
  * Consistent default request header applied across gateway traffic.
  * Cleaner client-facing paths via automatic path handling and a Search-specific path remap.
  * Queue requests now strip cookies to improve privacy; Search responses include a service-specific cookie for interoperability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->