### PR TITLE
[Phase 2] request rate limiter 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // macOS DNS resolver
     runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.115.Final:osx-aarch_64'

--- a/src/main/java/site/donghyeon/gateway/config/RateLimitConfig.java
+++ b/src/main/java/site/donghyeon/gateway/config/RateLimitConfig.java
@@ -1,0 +1,21 @@
+package site.donghyeon.gateway.config;
+
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+
+@Configuration
+public class RateLimitConfig {
+
+    @Bean
+    public KeyResolver remoteAddressResolver() {
+        return exchange -> Mono.just(
+                Objects.requireNonNull(
+                        exchange.getRequest().getRemoteAddress()
+                ).getAddress().getHostAddress()
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,14 @@ spring:
         webflux:
           default-filters:
             - AddRequestHeader=X-gateway, donghyeon.site # 먼저 적용됨
+            - name: RequestRateLimiter
+              args:
+                key-resolver: '#{@remoteAddressResolver}' # 사용자 키 리졸버 가능
+                redis-rate-limiter:
+                  # Token Bucket 알고리즘 기반
+                  replenishRate: 50 # 초당 허용 요청 수
+                  burstCapacity: 100 # 버킷의 최대 용량 (순간 최대 요청 수)
+
           routes:
             - id: test-route
               uri: https://httpbin.org

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,3 +45,7 @@ spring:
               filters:
                 - StripPrefix=1
                 - RemoveRequestHeader=Cookie
+  data:
+    redis:
+      host: localhost
+      port: 6379


### PR DESCRIPTION
# 🧩 PR 요약
> 이번 PR의 목적과 핵심 변경사항을 간단히 적어주세요.  
(예: Redis 리더보드 구현)

- 구현 기능:
  - ip 기반 rate limiter 설정

- 수정/리팩토링 내용:

- 추가된 설정/의존성:
  - redis 의존성 추가 및 연결

---

## ⚙️ 주요 구현 내용
> 구현된 기능의 흐름이나 의도, 설계상의 선택 이유를 간단히 정리해주세요.  

- spring cloud gateway의 기능인 `rate limiter`를 학습했습니다.
- ip 기반의 `keyResolver`를 설정하고, 이를 통해 요청을 구분하도록 설정했습니다.
- 직접 요청을 보내며, 중복 요청 시 `429 Too Many Requests` 응답을 확인했습니다. 

---

## 🧠 학습 포인트 / 검증 이론
> 이번 작업에서 학습하거나 검증하고 싶은 기술적 개념을 기록합니다.  

- `keyResolver`는 rate limit 시 어떤 키를 사용할지 결정하는 컴포넌트입니다. 
- 기본적으로 `PrincipalNameKeyResolver`(인증 사용자 기준)가 제공되며, 이를 커스텀해 `@Bean`으로 등록하면 원하는 형태의 값으로 사용 가능합니다.
- `redis-rate-limiter` 설정 후 `GET /queue` 요청 시 두개의 키가 생성됩니다. 
  -  `request_rate_limiter.{queue.0:0:0:0:0:0:0:1}.tokens` (남은 토큰 수)
  -  `request_rate_limiter.{queue.0:0:0:0:0:0:0:1}.timestamp` (마지막 요청 시각)
- 즉, Redis가 IP별 토큰 버킷 상태를 저장하고, 재요청 시 TTL 기반으로 토큰을 보충 및 소모합니다.
- rate limiter는 Token Buckets 알고리즘 기반으로 동작합니다.
  - Token Buckets 알고리즘은 일정시간마다 토큰이 재충전되고, 요청시마다 1개의 토큰이 소모되며, 버킷이 비어 있으면 `429 Too Many Requests`를 반환합니다. 
  - 이를 통해 지속적인 요청 제어가 가능합니다. 
---

## ✅ 검증 및 테스트
> PR을 올리기 전에 확인한 사항을 체크해주세요.

- [x] 빌드 및 서버 실행 확인 (`./gradlew bootRun`)
- [x] 신규 API 테스트 완료
- [x] 로깅/예외 처리 정상 동작
- [x] 불필요한 로그 제거
- [x] 학습 내용을 커밋 메시지 또는 주석으로 요약

---

## 📚 참고 자료
> 참고한 공식 문서나 블로그, 영상 링크 등을 작성해주세요.

- 공식 문서: [6.22. The RequestRateLimiter GatewayFilter Factory](https://docs.spring.io/spring-cloud-gateway/docs/current/reference/html/#the-requestratelimiter-gatewayfilter-factory)
- 블로그/자료:
- 기타 참고 링크:

---

## 🚀 다음 학습/개선 아이디어 (선택)
> 이번 구현을 기반으로 더 시도해볼 내용이 있다면 적어주세요.

- 유저 인증 기반 제어가 필요한 경우 기본값인 `PrinicpalNameKeyResolver`를 사용할 수도 있습니다.
- KeyResolver가 IP를 바라보고 있는 경우, 프록시 환경에서는 예기치 않은 동작이 일어날 수 있으므로 `X-Forwarded-For` 헤더 기준으로 변경이 필요합니다. 
- Redis는 단일 장애점이 됩니다. 운영 환경에서는 더 나은 설계가 필요합니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gateway request rate limiting per client IP to improve reliability under load. Defaults allow up to 50 requests per second with short bursts up to 100; excess requests may be throttled. Please retry after a brief pause if limits are reached.
  * Enabled distributed throttling using Redis for consistent enforcement across instances, enhancing stability in multi-node deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->