### PR TITLE
[Phase 3] Circuit Breaker, Retry를 통한 회복력 패턴

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,8 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
-    implementation 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
     // macOS DNS resolver
     runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.115.Final:osx-aarch_64'

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
 
     // macOS DNS resolver
     runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.115.Final:osx-aarch_64'

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
+    implementation 'org.projectlombok:lombok'
 
     // macOS DNS resolver
     runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.115.Final:osx-aarch_64'

--- a/src/main/java/site/donghyeon/gateway/handler/FallbackController.java
+++ b/src/main/java/site/donghyeon/gateway/handler/FallbackController.java
@@ -1,5 +1,6 @@
 package site.donghyeon.gateway.handler;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
@@ -7,10 +8,11 @@ import reactor.core.publisher.Mono;
 import java.util.Map;
 
 @RestController
+@Slf4j
 public class FallbackController {
     @GetMapping("/__fallback")
     public Mono<Map<String, String>> fallback() {
-        System.out.println("check fallback");
+        log.error("Circuit breaker fallback triggered");
         return Mono.just(Map.of("status", "fallback", "message", "Service temporarily unavailable"));
     }
 }

--- a/src/main/java/site/donghyeon/gateway/handler/FallbackController.java
+++ b/src/main/java/site/donghyeon/gateway/handler/FallbackController.java
@@ -11,6 +11,13 @@ import java.util.Map;
 @RestController
 @Slf4j
 public class FallbackController {
+    /**
+     * Provides a fixed fallback HTTP response used when a circuit breaker is triggered.
+     *
+     * The response map contains keys "status" and "message" describing the fallback state.
+     *
+     * @return a map with "status" -> "fallback" and "message" -> "Service temporarily unavailable"
+     */
     @GetMapping("/__fallback")
     public Mono<Map<String, String>> fallback(ServerWebExchange exchange) {
         log.warn("Circuit breaker fallback triggered for request: {}", exchange.getRequest().getId());

--- a/src/main/java/site/donghyeon/gateway/handler/FallbackController.java
+++ b/src/main/java/site/donghyeon/gateway/handler/FallbackController.java
@@ -3,6 +3,7 @@ package site.donghyeon.gateway.handler;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 import java.util.Map;
@@ -11,8 +12,8 @@ import java.util.Map;
 @Slf4j
 public class FallbackController {
     @GetMapping("/__fallback")
-    public Mono<Map<String, String>> fallback() {
-        log.error("Circuit breaker fallback triggered");
+    public Mono<Map<String, String>> fallback(ServerWebExchange exchange) {
+        log.warn("Circuit breaker fallback triggered for request: {}", exchange.getRequest().getId());
         return Mono.just(Map.of("status", "fallback", "message", "Service temporarily unavailable"));
     }
 }

--- a/src/main/java/site/donghyeon/gateway/handler/FallbackController.java
+++ b/src/main/java/site/donghyeon/gateway/handler/FallbackController.java
@@ -1,6 +1,8 @@
 package site.donghyeon.gateway.handler;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ServerWebExchange;
@@ -19,8 +21,17 @@ public class FallbackController {
      * @return a map with "status" -> "fallback" and "message" -> "Service temporarily unavailable"
      */
     @GetMapping("/__fallback")
-    public Mono<Map<String, String>> fallback(ServerWebExchange exchange) {
+    public Mono<ResponseEntity<Map<String,String>>> fallback(ServerWebExchange exchange) {
         log.warn("Circuit breaker fallback triggered for request: {}", exchange.getRequest().getId());
-        return Mono.just(Map.of("status", "fallback", "message", "Service temporarily unavailable"));
+        return Mono.just(
+                ResponseEntity
+                        .status(HttpStatus.SERVICE_UNAVAILABLE)
+                        .body(
+                                Map.of(
+                                        "status", "fallback",
+                                        "message", "Service temporarily unavailable"
+                                )
+                        )
+        );
     }
 }

--- a/src/main/java/site/donghyeon/gateway/handler/FallbackController.java
+++ b/src/main/java/site/donghyeon/gateway/handler/FallbackController.java
@@ -1,0 +1,16 @@
+package site.donghyeon.gateway.handler;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+@RestController
+public class FallbackController {
+    @GetMapping("/__fallback")
+    public Mono<Map<String, String>> fallback() {
+        System.out.println("check fallback");
+        return Mono.just(Map.of("status", "fallback", "message", "Service temporarily unavailable"));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,3 +63,16 @@ spring:
     redis:
       host: localhost
       port: 6379
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        failureRateThreshold: 50
+        waitDurationInOpenState: 10s
+  timelimiter:
+    configs:
+      default:
+        timeoutDuration: 5s  # 타임아웃 5초로 증가

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -92,3 +92,8 @@ resilience4j:
     configs:
       default:
         timeoutDuration: 5s  # 타임아웃 5초로 증가
+
+logging:
+  level:
+    org.springframework.cloud.gateway: DEBUG
+    reactor.retry: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,15 @@ spring:
                 name: defaultCB
                 fallbackUri: forward:/__fallback
 
+            - name: Retry
+              args:
+                retries: 3
+                methods: GET
+                backoff:
+                  firstBackoff: 50ms
+                  maxBackoff: 500ms
+                  factor: 2
+
           routes:
             - id: test-route
               uri: https://httpbin.org

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,6 +59,13 @@ spring:
               filters:
                 - StripPrefix=1
                 - RemoveRequestHeader=Cookie
+
+            - id: dead-server
+              uri: http://localhost:9999  # 존재하지 않는 백엔드
+              predicates:
+                - Path=/dead/**
+              filters:
+                - StripPrefix=1
   data:
     redis:
       host: localhost

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
         webflux:
           default-filters:
             - AddRequestHeader=X-gateway, donghyeon.site # 먼저 적용됨
+
             - name: RequestRateLimiter
               args:
                 key-resolver: '#{@remoteAddressResolver}' # 사용자 키 리졸버 가능
@@ -18,6 +19,11 @@ spring:
                   # Token Bucket 알고리즘 기반
                   replenishRate: 50 # 초당 허용 요청 수
                   burstCapacity: 100 # 버킷의 최대 용량 (순간 최대 요청 수)
+
+            - name: CircuitBreaker
+              args:
+                name: defaultCB
+                fallbackUri: forward:/__fallback
 
           routes:
             - id: test-route


### PR DESCRIPTION
# 🧩 PR 요약
> 이번 PR의 목적과 핵심 변경사항을 간단히 적어주세요.  
(예: Redis 리더보드 구현)

- 구현 기능:
  - Circuit Breaker 설정
  - Retry 설정
  - fallback endpoint 추가
- 수정/리팩토링 내용:

- 추가된 설정/의존성:
  - Resilience4j 의존성 추가
  - logging 설정 추가
---

## ⚙️ 주요 구현 내용
> 구현된 기능의 흐름이나 의도, 설계상의 선택 이유를 간단히 정리해주세요.  

- spring cloud gateway의 기능인 `CircuitBreaker` 패턴과 `Retry` 패턴을 학습했습니다.
- `Resilience4j`의 `CircuitBreaker` 구현체를 사용합니다.
- `httpbin.org`의 경우, 응답에 시간이 다소 소요되어 테스트가 불가해 타임아웃을 5초로 설정했습니다.
- 멱등성이 보장된 `GET`요청에 Retry 설정을 추가하고, 이를 테스트하기 위해 존재하지 않는 포트에 대한 라우터를 설정해 테스트를 진행했습니다. 

---

## 🧠 학습 포인트 / 검증 이론
> 이번 작업에서 학습하거나 검증하고 싶은 기술적 개념을 기록합니다.  
- Circuit Breaker
  - 외부 서비스의 장애가 연속적으로 발생할 때, 전체 시스템이 연쇄적으로 느려지거나 멈추는 현상을 방지하기 위한 보호 메커니즘입니다.
  - CLOSED -> OPEN -> HALF_OPEN -> CLOSED 상태 전이를 통해 요청의 흐름을 제어합니다.
  - 특정 시간`waitDurationInOpenState` 동안 실패율`failureRateThreshold`이 기준치를 넘으면 OPEN 상태로 전환되어 모든 요청을 차단합니다.
  - 이후 일정 시간이 지나면 HALF_OPEN으로 일부 요청만 시도해 정상 여부를 판단합니다.

- Resilience4j의 CircuitBreaker
  - CircuitBreaker는 기본적으로 spring cloud gateway에 포함된 인터페이스고, Resilience4j는 CircuitBreaker의 구현체를 제공합니다. 

- Retry 패턴의 작동 방식
  - 멱등성이 보장되는 요청에만 적용하는 것이 원칙입니다.
  - 실패 시 지정 횟수`retries`만큼 백오프`backoff` 간격을 두고 재요청합니다. 
  - `factor`값으로 지수적 증가 테스트를 진행했습니다.
  - CircuitBreaker와 조합 시, Retry가 Circuit내부에서 호출되므로 OPEN 상태에서는 Retry가 동작하지 않습니다.

- Fallback
  - Circuit이 OPEN 상태일 때, fallbackUri를 통해 대체 응답을 반환하도록 설정합니다.
  - 이 과정을 통해 실제 트래픽 중단 없이 Graceful Degradation을 구현합니다.

---

## ✅ 검증 및 테스트
> PR을 올리기 전에 확인한 사항을 체크해주세요.

- [x] 빌드 및 서버 실행 확인 (`./gradlew bootRun`)
- [x] 신규 API 테스트 완료
- [x] 로깅/예외 처리 정상 동작
- [x] 불필요한 로그 제거
- [x] 학습 내용을 커밋 메시지 또는 주석으로 요약

---

## 📚 참고 자료
> 참고한 공식 문서나 블로그, 영상 링크 등을 작성해주세요.

- 공식 문서: 
  - [6.5. The CircuitBreaker GatewayFilter Factory](https://docs.spring.io/spring-cloud-gateway/docs/current/reference/html/#spring-cloud-circuitbreaker-filter-factory)
  - [resilience4j documentation](https://resilience4j.readme.io/docs/getting-started)
- 블로그/자료:
- 기타 참고 링크:

---

## 🚀 다음 학습/개선 아이디어 (선택)
> 이번 구현을 기반으로 더 시도해볼 내용이 있다면 적어주세요.

- 각 서버 별 독립적인 CircuitBreaker를 설정할 수도 있습니다. 
  - resilience4j 설정에서 instaces를 나누고, 라우터 필터에서 name 파라미터를 다르게 주면 각 서버마다 독립적인 CircuitBreaker를 설정할 수 있습니다.
  - 이를 통해 중요 서비스는 `failureRateThreshold`를 높게, 불안정한 서비스는 낮게 설정하는 등 서비스마다 필요한 요구사항을 동적으로 조절할 수 있습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gateway fallback handling that returns a clear status/message when upstream is unavailable.
  * Added a fallback status endpoint for quick visibility during disruptions.
  * Enabled automatic retries for safe GET requests with exponential backoff.
  * Added a /dead/** test route to simulate unavailable backends with path stripping.

* **Chores**
  * Tuned circuit-breaker and timeout defaults; enabled detailed gateway and retry debug logs.
  * Added dependencies to enable resilience/circuit-breaker and developer tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->