### PR TITLE
[Phase 5] 커스텀 필터

### DIFF
--- a/src/main/java/site/donghyeon/gateway/config/SecurityConfig.java
+++ b/src/main/java/site/donghyeon/gateway/config/SecurityConfig.java
@@ -2,24 +2,35 @@ package site.donghyeon.gateway.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
 
 @Configuration
 public class SecurityConfig {
 
     @Bean
+    @Order(1)
+    public SecurityWebFilterChain publicFilterChain(ServerHttpSecurity http) {
+        return http
+                .securityMatcher(ServerWebExchangeMatchers.pathMatchers("/test/**", "/dead/**"))
+                .authorizeExchange(exchange -> exchange.anyExchange().permitAll())
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .build();
+    }
+
+    @Bean
+    @Order(2)
     public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
         return http
                 .authorizeExchange(exchange -> exchange
-                        .pathMatchers("/test/**").permitAll()
-                        // 권한 기반 라우팅 예시
                         .pathMatchers("/book/**").hasRole("ADMIN")
                         .pathMatchers("/search/**").hasAnyRole("USER", "ADMIN")
                         .anyExchange().authenticated()
                 )
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt
-                        .jwtAuthenticationConverter(jwtRoleConverter())  // ← 커스텀 Converter 등록
+                        .jwtAuthenticationConverter(jwtRoleConverter())
                 ))
                 .build();
     }

--- a/src/main/java/site/donghyeon/gateway/config/filter/IdempotencyHeaderFilter.java
+++ b/src/main/java/site/donghyeon/gateway/config/filter/IdempotencyHeaderFilter.java
@@ -32,7 +32,6 @@ public class IdempotencyHeaderFilter implements GlobalFilter, Ordered {
 
     private boolean isNonIdempotentMethod(HttpMethod httpMethod) {
         return httpMethod == HttpMethod.POST ||
-                httpMethod == HttpMethod.PUT ||
                 httpMethod == HttpMethod.PATCH;
     }
 

--- a/src/main/java/site/donghyeon/gateway/config/filter/IdempotencyHeaderFilter.java
+++ b/src/main/java/site/donghyeon/gateway/config/filter/IdempotencyHeaderFilter.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
@@ -20,8 +21,7 @@ public class IdempotencyHeaderFilter implements GlobalFilter, Ordered {
         ServerHttpRequest request = exchange.getRequest();
         if (isNonIdempotentMethod(request.getMethod())) {
             String idempotencyKey = request.getHeaders().getFirst("Idempotency-Key");
-            if (idempotencyKey == null || idempotencyKey.isEmpty()) {
-                log.debug("Empty Idempotency-Key in request, {}", request.getHeaders().getFirst("traceparent"));
+            if (StringUtils.hasText(idempotencyKey)) {
                 exchange.getResponse().setStatusCode(HttpStatus.BAD_REQUEST);
                 return exchange.getResponse().setComplete();
             }

--- a/src/main/java/site/donghyeon/gateway/config/filter/IdempotencyHeaderFilter.java
+++ b/src/main/java/site/donghyeon/gateway/config/filter/IdempotencyHeaderFilter.java
@@ -21,7 +21,7 @@ public class IdempotencyHeaderFilter implements GlobalFilter, Ordered {
         ServerHttpRequest request = exchange.getRequest();
         if (isNonIdempotentMethod(request.getMethod())) {
             String idempotencyKey = request.getHeaders().getFirst("Idempotency-Key");
-            if (StringUtils.hasText(idempotencyKey)) {
+            if (!StringUtils.hasText(idempotencyKey)) {
                 log.debug("Idempotency-Key header is required, {}", request.getHeaders().getFirst("traceparent"));
                 exchange.getResponse().setStatusCode(HttpStatus.BAD_REQUEST);
                 return exchange.getResponse().setComplete();

--- a/src/main/java/site/donghyeon/gateway/config/filter/IdempotencyHeaderFilter.java
+++ b/src/main/java/site/donghyeon/gateway/config/filter/IdempotencyHeaderFilter.java
@@ -1,0 +1,42 @@
+package site.donghyeon.gateway.config.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+public class IdempotencyHeaderFilter implements GlobalFilter, Ordered {
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        ServerHttpRequest request = exchange.getRequest();
+        if (isNonIdempotentMethod(request.getMethod())) {
+            String idempotencyKey = request.getHeaders().getFirst("Idempotency-Key");
+            if (idempotencyKey == null || idempotencyKey.isEmpty()) {
+                log.debug("Empty Idempotency-Key in request, {}", request.getHeaders().getFirst("traceparent"));
+                exchange.getResponse().setStatusCode(HttpStatus.BAD_REQUEST);
+                return exchange.getResponse().setComplete();
+            }
+        }
+        return chain.filter(exchange);
+    }
+
+    private boolean isNonIdempotentMethod(HttpMethod httpMethod) {
+        return httpMethod == HttpMethod.POST ||
+                httpMethod == HttpMethod.PUT ||
+                httpMethod == HttpMethod.PATCH;
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE + 1;
+    }
+}

--- a/src/main/java/site/donghyeon/gateway/config/filter/IdempotencyHeaderFilter.java
+++ b/src/main/java/site/donghyeon/gateway/config/filter/IdempotencyHeaderFilter.java
@@ -22,6 +22,7 @@ public class IdempotencyHeaderFilter implements GlobalFilter, Ordered {
         if (isNonIdempotentMethod(request.getMethod())) {
             String idempotencyKey = request.getHeaders().getFirst("Idempotency-Key");
             if (StringUtils.hasText(idempotencyKey)) {
+                log.debug("Idempotency-Key header is required, {}", request.getHeaders().getFirst("traceparent"));
                 exchange.getResponse().setStatusCode(HttpStatus.BAD_REQUEST);
                 return exchange.getResponse().setComplete();
             }

--- a/src/main/java/site/donghyeon/gateway/config/filter/TraceHeaderFilter.java
+++ b/src/main/java/site/donghyeon/gateway/config/filter/TraceHeaderFilter.java
@@ -35,11 +35,14 @@ public class TraceHeaderFilter implements GlobalFilter, Ordered {
      */
     private String generateTraceId() {
         // trace-id: 32자리 hex (128비트)
-        String traceId = generateRandomHex(16);
-
+        String traceId, parentId;
+        do {
+            traceId = generateRandomHex(16);
+        } while (traceId.equals("0".repeat(32)));
         // parent-id (span-id): 16자리 hex (64비트)
-        String parentId = generateRandomHex(8);
-
+        do {
+            parentId = generateRandomHex(8);
+        }  while (parentId.equals("0".repeat(16)));
         // trace-flags: 01 (sampled)
         return String.format("00-%s-%s-01", traceId, parentId);
     }

--- a/src/main/java/site/donghyeon/gateway/config/filter/TraceHeaderFilter.java
+++ b/src/main/java/site/donghyeon/gateway/config/filter/TraceHeaderFilter.java
@@ -1,0 +1,70 @@
+package site.donghyeon.gateway.config.filter;
+
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.security.SecureRandom;
+import java.util.Random;
+
+@Component
+public class TraceHeaderFilter implements GlobalFilter, Ordered {
+
+    private static final Random RANDOM = new SecureRandom();
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        if (!exchange.getRequest().getHeaders().containsKey("traceparent")) {
+            String traceParent = generateTraceId();
+            exchange = exchange.mutate()
+                    .request(r -> r.header("traceparent", traceParent))
+                    .build();
+        }
+        return chain.filter(exchange);
+    }
+
+    /**
+     * W3C Trace Context 표준에 따른 traceparent 헤더 생성
+     * 형식: 00-{trace-id}-{parent-id}-{trace-flags}
+     *
+     * @return traceparent 헤더 문자열 (예: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01)
+     */
+    private String generateTraceId() {
+        // trace-id: 32자리 hex (128비트)
+        String traceId = generateRandomHex(16);
+
+        // parent-id (span-id): 16자리 hex (64비트)
+        String parentId = generateRandomHex(8);
+
+        // trace-flags: 01 (sampled)
+        return String.format("00-%s-%s-01", traceId, parentId);
+    }
+
+    private String generateRandomHex(int byteCount) {
+        byte[] bytes = new byte[byteCount];
+        RANDOM.nextBytes(bytes);
+        StringBuilder sb = new StringBuilder(byteCount * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * 필터 실행 순서 지정
+     * 낮은 숫자일수록 먼저 실행됨
+     * TraceHeaderFilter는 다른 모든 필터보다 먼저 실행되어야
+     * 후속 필터들이 trace ID를 사용할 수 있음
+     *
+     * @return HIGHEST_PRECEDENCE (-2147483648)
+     */
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+}
+
+

--- a/src/main/java/site/donghyeon/gateway/config/filter/TraceHeaderFilter.java
+++ b/src/main/java/site/donghyeon/gateway/config/filter/TraceHeaderFilter.java
@@ -10,15 +10,19 @@ import reactor.core.publisher.Mono;
 import java.security.SecureRandom;
 import java.util.HexFormat;
 import java.util.Random;
+import java.util.regex.Pattern;
 
 @Component
 public class TraceHeaderFilter implements GlobalFilter, Ordered {
 
     private static final Random RANDOM = new SecureRandom();
+    private static final Pattern TRACEPARENT_PATTERN =
+            Pattern.compile("^[0-9a-f]{2}-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$");
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
-        if (!exchange.getRequest().getHeaders().containsKey("traceparent")) {
+        String traceparentHeader = exchange.getRequest().getHeaders().getFirst("traceparent");
+        if (traceparentHeader == null || !TRACEPARENT_PATTERN.matcher(traceparentHeader).matches()) {
             String traceParent = generateTraceId();
             exchange = exchange.mutate()
                     .request(r -> r.header("traceparent", traceParent))

--- a/src/main/java/site/donghyeon/gateway/config/filter/TraceHeaderFilter.java
+++ b/src/main/java/site/donghyeon/gateway/config/filter/TraceHeaderFilter.java
@@ -8,6 +8,7 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 import java.security.SecureRandom;
+import java.util.HexFormat;
 import java.util.Random;
 
 @Component
@@ -46,11 +47,7 @@ public class TraceHeaderFilter implements GlobalFilter, Ordered {
     private String generateRandomHex(int byteCount) {
         byte[] bytes = new byte[byteCount];
         RANDOM.nextBytes(bytes);
-        StringBuilder sb = new StringBuilder(byteCount * 2);
-        for (byte b : bytes) {
-            sb.append(String.format("%02x", b));
-        }
-        return sb.toString();
+        return HexFormat.of().formatHex(bytes);
     }
 
     /**


### PR DESCRIPTION
# 🧩 PR 요약
> 이번 PR의 목적과 핵심 변경사항을 간단히 적어주세요.  
(예: Redis 리더보드 구현)

- 구현 기능:
  - 분산 서비스 간 요청 추적을 위한 `traceparent` 헤더 생성 및 전파
  - 멱등성 보장을 위한 `Idempotency-Key` 헤더 검증
- 수정/리팩토링 내용:
  - `SecurityConfig`를 인증 여부에 따라 두 개의 FilterChain으로 분리
  - 공개 경로(`/test/**`, `/dead/**`)에서 JWT 검증 우회
- 추가된 설정/의존성:

---

## ⚙️ 주요 구현 내용
> 구현된 기능의 흐름이나 의도, 설계상의 선택 이유를 간단히 정리해주세요.  

- MSA 환경에서 한 요청이 여러 서비스를 거쳐갈 때 전체 흐름을 추적하기 위해, W3C Trace Context 표준에 따른 `traceparent` 헤더를 생성합니다.
  - `TraceHeaderFilter`를 통해 게이트웨이 진입 시점에 `trace-id`를 부여하고, 하위 서비스로 요청을 전달할 때 헤더를 함께 전파합니다.
-`POST` 요청이 네트워크 타임아웃 등으로 실패했을 때, 클라이언트가 재시도하면 중복 데이터가 생성될 수 있습니다.
  - 게이트웨이는 헤더 존재 여부만 검증하며, 실제 중복 방지 로직은 각 백엔드 서비스에서 구현합니다. 

---

## 🧠 학습 포인트 / 검증 이론
> 이번 작업에서 학습하거나 검증하고 싶은 기술적 개념을 기록합니다.  

- W3C Trace Context 표준
  - 분산 시스템에서 요청을 추적하기 위한 국제 표준 규격
  - `00-{trace-id}-{span-id}-{trace-flags}`

- `GlobalFilter`와 필터 실행 순서
  - `GlobalFilter`는 모든 라우트에 공통 적용되는 필터로, 인증/추적/로깅 등 횡단 관심사를 구현합니다.
  - `Ordered` 인터페이스로 필터 우선순위를 제어하며, 낮은 숫자일수록 먼저 실행됩니다.

- `Idempotency-Key` 패턴의 책임 분리
  - `POST`, `PUT`, `PATCH` 등 비멱등 요청의 안전한 재시도를 위한 패턴입니다.
  - 네트워크 타임아웃 등으로 응답을 받지 못한 클라이언트가 동일한 키로 재시도하면, 서버는 중복 실행 없이 캐시된 응답을 반환합니다. 

---

## ✅ 검증 및 테스트
> PR을 올리기 전에 확인한 사항을 체크해주세요.

- [x] 빌드 및 서버 실행 확인 (`./gradlew bootRun`)
- [x] 신규 API 테스트 완료
- [x] 로깅/예외 처리 정상 동작
- [x] 불필요한 로그 제거
- [x] 학습 내용을 커밋 메시지 또는 주석으로 요약

---

## 📚 참고 자료
> 참고한 공식 문서나 블로그, 영상 링크 등을 작성해주세요.

- 공식 문서:
  - [Trace Context](https://www.w3.org/TR/trace-context)
  - [7. Global Filters](https://docs.spring.io/spring-cloud-gateway/docs/current/reference/html/#global-filters)
- 블로그/자료:
  - [멱등성이 뭔가요?](https://docs.tosspayments.com/blog/what-is-idempotency)
- 기타 참고 링크:

---

## 🚀 다음 학습/개선 아이디어 (선택)
> 이번 구현을 기반으로 더 시도해볼 내용이 있다면 적어주세요.

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public endpoints: requests to /test/** and /dead/** no longer require authentication.
  * Automatic traceability: all incoming requests are ensured to include a W3C-compliant traceparent header for consistent distributed tracing.
  * Idempotency enforcement: POST and PATCH requests carrying an Idempotency-Key header are rejected with 400 Bad Request.
  * Custom JWT role mapping: improved JWT role conversion for more accurate role handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->